### PR TITLE
Remove static arrays, allow variable length inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,20 +32,20 @@ ForwardDiff = {rev = "rv/remove-quote-assert-string-interpolation", url = "https
 SciMLBase = {rev = "as/fix-jet-opt", url = "https://github.com/AayushSabharwal/SciMLBase.jl"}
 
 [compat]
-ADTypes = "1.16.0"
-CEnum = "0.5.0"
-DiffEqBase = "6.179.0"
-ForwardDiff = "1.0.1"
-LinearAlgebra = "1.11.0,1.12.0"
-LinearSolve = "3.23.0"
+ADTypes = "^1.16.0"
+CEnum = "^0.5.0"
+DiffEqBase = "^6.179.0"
+ForwardDiff = "^1.0.1"
+LinearAlgebra = "^1.11.0"
+LinearSolve = "^3.25.0"
 Moshi = "0.3.7"
-NonlinearSolveBase = "1.13.0"
-NonlinearSolveFirstOrder = "1.7.0"
+NonlinearSolveBase = "^1.13.0"
+NonlinearSolveFirstOrder = "^1.7.0"
 Polyester = "0.7.18"
 PolyesterWeave = "0.2.2"
 PrecompileTools = "1"
 ProbabilisticParameterEstimators = "0.8.0,0.8.1,0.8.2"
-SciMLBase = "2.102.1"
+SciMLBase = "^2.102.1"
 StatsBase = "0.34.5"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,6 @@ XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 
 [sources]
 ForwardDiff = {rev = "rv/remove-quote-assert-string-interpolation", url = "https://github.com/RomeoV/ForwardDiff.jl.git"}
-LinearSolve = {rev = "rv/allow-mmatrix-cache", url = "https://github.com/RomeoV/LinearSolve.jl"}
 SciMLBase = {rev = "as/fix-jet-opt", url = "https://github.com/AayushSabharwal/SciMLBase.jl"}
 
 [compat]

--- a/STATIC_ARRAY_REMOVAL_PLAN.md
+++ b/STATIC_ARRAY_REMOVAL_PLAN.md
@@ -1,0 +1,76 @@
+# Static Array Removal Implementation Plan
+
+## Goal
+Remove static arrays from pose estimation to allow flexibility in number of keypoints, while keeping static arrays where they provide performance benefits for small, fixed-size data structures.
+
+## What Should REMAIN as Static Arrays
+- `WorldPoint`, `CameraPoint`, `ProjectionPoint` - These are FieldVectors with 2-3 elements, perfect for static arrays
+- Small rotation vectors (3 elements)
+- Small error vectors within individual computations
+- Any fixed-size mathematical operations
+
+## What Should BECOME Regular Arrays
+- Collections of points (runway_corners, observed_corners, projected_corners)
+- Cache initialization vectors (u0 for optimization)
+- Any data structure that needs to vary in size based on number of keypoints
+
+## Current Issues Found
+
+### 1. C API Issues
+- `RotYPRF64` changed from `SVector{3,Float64}` to `Vector{Float64}` - this breaks C interop
+- The C API expects fixed-size data structures for interop
+- **Fix**: Keep `RotYPRF64` as `SVector{3,Float64}` but handle conversions properly
+
+### 2. Type Mismatches
+- Some functions expect static arrays but now receive regular arrays
+- Need to be careful about where conversions happen
+
+### 3. Test Failures
+- C API tests failing due to type mismatches with rotation vectors
+- Need to fix the pointer conversions
+
+## Implementation Strategy
+
+### Phase 1: Fix Core Pose Estimation (DONE)
+- ✅ Remove MVector from cache initialization  
+- ✅ Change collections of points to regular arrays
+- ✅ Update error vector concatenation
+
+### Phase 2: Fix C API (IN PROGRESS)
+- 🔄 Keep rotation types as SVector for C interop
+- 🔄 Fix unsafe_convert issues
+- 🔄 Ensure point collections work with variable sizes
+
+### Phase 3: Update Tests
+- 🔄 Fix C API test failures
+- ⏸️ Add tests for varying keypoint numbers (8, 16)
+
+### Phase 4: Cleanup
+- ⏸️ Remove forked LinearSolve dependency
+- ⏸️ Move const caches to function scope if needed
+
+## Specific Files to Modify
+
+### src/pose_estimation/optimization.jl
+- ✅ Remove `using StaticArrays: MVector`
+- ✅ Change cache initialization from MVector to regular arrays
+- ✅ Update error vector creation
+- ✅ Change default parameters from SA[...] to [...]
+
+### src/c_api.jl  
+- 🔄 **REVERT** RotYPRF64 back to SVector{3,Float64}
+- 🔄 Fix array conversions for point collections
+- 🔄 Handle variable-size point arrays properly
+
+### test files
+- ✅ Change test data from SA[...] to [...]
+- 🔄 Fix C API test pointer issues
+
+### src/precompile_workloads.jl
+- ✅ Change runway_corners from SA[...] to [...]
+
+## Next Steps
+1. Fix RotYPRF64 type back to SVector for C compatibility
+2. Fix unsafe_convert issues in C API tests
+3. Test with varying numbers of keypoints
+4. Clean up dependencies

--- a/src/c_api.jl
+++ b/src/c_api.jl
@@ -105,8 +105,8 @@ Base.@ccallable function estimate_pose_6dof(
     end
 
     # Convert C arrays to Julia arrays
-    runway_corners = unsafe_wrap(Array, runway_corners_, num_points) .* 1m |> SVector{4}
-    projections = unsafe_wrap(Array, projections_, num_points) .* 1px |> SVector{4}
+    runway_corners = unsafe_wrap(Array, runway_corners_, num_points) .* 1m
+    projections = unsafe_wrap(Array, projections_, num_points) .* 1px
 
 
     # Get camera configuration
@@ -159,8 +159,8 @@ Base.@ccallable function estimate_pose_3dof(
     end
 
     # Convert C arrays to Julia arrays
-    runway_corners = unsafe_wrap(Array, runway_corners_, num_points) .* 1m |> SVector{4}
-    projections = unsafe_wrap(Array, projections_, num_points) .* 1px |> SVector{4}
+    runway_corners = unsafe_wrap(Array, runway_corners_, num_points) .* 1m
+    projections = unsafe_wrap(Array, projections_, num_points) .* 1px
     known_rot_c = unsafe_load(known_rotation)
 
     # Convert rotation to Julia type

--- a/src/pose_estimation/optimization.jl
+++ b/src/pose_estimation/optimization.jl
@@ -98,7 +98,7 @@ function pose_optimization_objective(
     error_vectors = [
         # we change the type here from a strongly typed "ProjectionPoint"
         # to a more weakly typed vector because we are about to concatenate them
-        vec(proj - obs)
+        (proj - obs) |> Array
             for (proj, obs) in zip(projected_corners, ps.observed_corners)
     ]
     errors = reduce(vcat, error_vectors)

--- a/src/precompile_workloads.jl
+++ b/src/precompile_workloads.jl
@@ -12,7 +12,7 @@ PrecompileTools.@compile_workload begin
     using Unitful: m, NoUnits, ustrip
 
     # Define typical runway corners (rectangular runway)
-    runway_corners = SA[
+    runway_corners = [
         WorldPoint(0.0m, -50.0m, 0.0m),
         WorldPoint(0.0m, 50.0m, 0.0m),
         WorldPoint(3000.0m, 50.0m, 0.0m),

--- a/test/unit/test_jet.jl
+++ b/test/unit/test_jet.jl
@@ -31,7 +31,7 @@ using StaticArrays
 
     @testset "Pose Estimation Functions" begin
         # Test data for pose estimation
-        runway_corners = SA[
+        runway_corners = [
             WorldPoint(0.0m, -50.0m, 0.0m),
             WorldPoint(0.0m, 50.0m, 0.0m),
             WorldPoint(3000.0m, 50.0m, 0.0m),
@@ -64,7 +64,7 @@ using StaticArrays
             @test_opt RunwayLib.pose_optimization_objective(opt_params_6dof, ps_6dof)
             
             # Test 3-DOF optimization parameters
-            opt_params_3dof = [-500.0, 10.0, 100.0]  # position only
+            opt_params_3dof = SA[-500.0, 10.0, 100.0]  # position only
             
             ps_3dof = PoseOptimizationParams3DOF(
                 runway_corners, projections,

--- a/test/unit/test_pose_estimation.jl
+++ b/test/unit/test_pose_estimation.jl
@@ -7,7 +7,7 @@ using StaticArrays
 
 @testset "Pose Estimation" begin
     # Define standard runway corners (4 points forming a rectangle)
-    runway_corners = SA[
+    runway_corners = [
         WorldPoint(0.0m, 25.0m, 0.0m),      # near left  
         WorldPoint(0.0m, -25.0m, 0.0m),     # near right
         WorldPoint(1000.0m, 25.0m, 0.0m),   # far left
@@ -32,8 +32,8 @@ using StaticArrays
         true_projections = [project(true_pos, true_rot, corner, config) for corner in runway_corners]
 
         # Create noisy initial guesses
-        noisy_pos_guess = SA[true_pos.x + 100.0m, true_pos.y - 20.0m, true_pos.z + 30.0m]
-        noisy_rot_guess = SA[true_rot.theta1 + 0.05, true_rot.theta2 - 0.08, true_rot.theta3 + 0.03]rad
+        noisy_pos_guess = [true_pos.x + 100.0m, true_pos.y - 20.0m, true_pos.z + 30.0m]
+        noisy_rot_guess = [true_rot.theta1 + 0.05, true_rot.theta2 - 0.08, true_rot.theta3 + 0.03]rad
 
         @testset "6DOF Estimation" begin
             result = estimatepose6dof(
@@ -67,8 +67,8 @@ using StaticArrays
                 true_projections = [project(case.pos, case.rot, corner, CAMERA_CONFIG_OFFSET) for corner in runway_corners]
                 
                 # Large initial errors
-                noisy_pos = SA[case.pos.x + 200.0m, case.pos.y - 50.0m, case.pos.z + 80.0m]
-                noisy_rot = SA[case.rot.theta1 + 0.1, case.rot.theta2 - 0.15, case.rot.theta3 + 0.08]rad
+                noisy_pos = [case.pos.x + 200.0m, case.pos.y - 50.0m, case.pos.z + 80.0m]
+                noisy_rot = [case.rot.theta1 + 0.1, case.rot.theta2 - 0.15, case.rot.theta3 + 0.08]rad
                 
                 @testset "6DOF" begin
                     result = estimatepose6dof(


### PR DESCRIPTION
Also
- move to `Ref{CACHE}` structure
(actually we might not need this anymore and can move it to one fixed with `OncePerProcess`...)
- remove geodesic acceleration in LM algorithm
  (would be nice to re-activate once the reinit! with different output sizes works...)
- set CAMERA_CONFIG_OFFSET as default everywhere