### PR TITLE
Implement line feature support with Hough transform

### DIFF
--- a/.github/workflows/package-python.yml
+++ b/.github/workflows/package-python.yml
@@ -2,6 +2,9 @@ name: Package Python
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,8 @@
 ## Testing Tips
 
 - Note that often times you're better off running tests directly with something like `julia --project=test test/...` rather than `Pkg.test()` as it can take a long time.
+- I have the fish aliases ```
+alias juliaserver 'julia --startup-file=no -e "using DaemonMode; serve()"'
+alias juliaclient 'julia --startup-file=no -e "using DaemonMode; runargs()"'
+alias juliaclientexpr 'julia --startup-file=no -e "using DaemonMode; runexpr(\"begin; \$(ARGS[1]); end\")" -- '
+```. Since you use bash, you'll have to "type this out" explicitly. But you can assume a server is running, and directly interact this way to run simple scripts or tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@
 ## Testing Tips
 
 - Note that often times you're better off running tests directly with something like `julia --project=test test/...` rather than `Pkg.test()` as it can take a long time.
-- I have the fish aliases ```
-alias juliaserver 'julia --startup-file=no -e "using DaemonMode; serve()"'
-alias juliaclient 'julia --startup-file=no -e "using DaemonMode; runargs()"'
-alias juliaclientexpr 'julia --startup-file=no -e "using DaemonMode; runexpr(\"begin; \$(ARGS[1]); end\")" -- '
-```. Since you use bash, you'll have to "type this out" explicitly. But you can assume a server is running, and directly interact this way to run simple scripts or tests.
+- I have the bash aliases ```
+alias juliaserver='julia --startup-file=no -e "using DaemonMode; serve()"'
+alias juliaclient='julia --startup-file=no -e "using DaemonMode; runargs()"'
+alias juliaclientexpr='julia --startup-file=no -e "using DaemonMode; runexpr(\"begin; \$(ARGS[1]); end\")" -- '
+```. You can assume a server is running, and directly interact this way to run simple scripts or tests.

--- a/src/RunwayLib.jl
+++ b/src/RunwayLib.jl
@@ -54,7 +54,7 @@ export UncorrGaussianNoiseModel, CorrGaussianNoiseModel, NoiseModel, covmatrix
 export parse_covariance_data
 
 # Export camera model functions
-export get_focal_length_pixels, get_field_of_view, pixel_to_ray_direction
+export get_focal_length_pixels, get_field_of_view, pixel_to_ray_direction, getline
 
 # Export runway database functions
 export get_runway_corners, validate_runway_spec

--- a/src/RunwayLib.jl
+++ b/src/RunwayLib.jl
@@ -1,7 +1,7 @@
 module RunwayLib
 
 using Distributions: Distributions, Normal, Chisq, ccdf
-using LinearAlgebra: LinearAlgebra, /, cholesky
+using LinearAlgebra: LinearAlgebra, /, cholesky, UpperTriangular, LowerTriangular
 using LinearSolve: CholeskyFactorization, LinearSolve, NonlinearFunction,
     NonlinearLeastSquaresProblem, init
 using Rotations: Rotations, RotZYX, Rotation
@@ -10,7 +10,7 @@ using DifferentiationInterface: DifferentiationInterface, jacobian
 using NonlinearSolveFirstOrder: LevenbergMarquardt, NonlinearLeastSquaresProblem, NonlinearFunction,
     reinit!, solve!
 import StaticArrays: similar_type
-using StaticArrays: StaticArrays, FieldVector, SA, Size, SVector
+using StaticArrays: StaticArrays, FieldVector, SA, Size, SVector, SMatrix, MVector, setindex
 using TypedTables: TypedTables, Table
 using Unitful: Unitful, @u_str, @unit, NoUnits, Quantity, dimension, uconvert,
     ustrip, Length
@@ -66,10 +66,10 @@ export pixel, px
 export BehindCameraException
 
 # Include submodules
+include("camera_model/withdims.jl")
 include("coordinate_systems/types.jl")
 include("coordinate_systems/transformations.jl")
 include("pose_estimation/types.jl")
-include("camera_model/withdims.jl")
 include("camera_model/projection.jl")
 include("camera_model/errors.jl")
 # include("data_management/runway_database.jl")

--- a/src/RunwayLib.jl
+++ b/src/RunwayLib.jl
@@ -28,8 +28,16 @@ _reduce(f::F) where F = Base.Fix1(reduce, f)
 @unit pixel "pixel" Pixel 1 false
 const px = pixel
 
-# Register the pixel unit with Unitful
-Unitful.register(RunwayLib)
+# Capture basefactors at compile time (includes our custom pixel unit)
+const localunits = copy(Unitful.basefactors)
+
+# Runtime initialization to properly register units
+function __init__()
+    # Restore basefactors captured at compile time
+    merge!(Unitful.basefactors, localunits)
+    # Register the pixel unit with Unitful
+    Unitful.register(RunwayLib)
+end
 
 # Export coordinate system types
 export WorldPoint, CameraPoint, ProjectionPoint

--- a/src/coordinate_systems/types.jl
+++ b/src/coordinate_systems/types.jl
@@ -37,7 +37,7 @@ wp_sum = wp + wp2  # Element-wise addition
 wp_scaled = 2.0 * wp  # Scalar multiplication
 ```
 """
-struct WorldPoint{T} <: FieldVector{3, T}
+struct WorldPoint{T} <: FieldVector{3,T}
     x::T  # Along-track distance
     y::T  # Cross-track distance
     z::T  # Height above runway
@@ -74,7 +74,7 @@ println("Right: ", cp.y)
 println("Down: ", cp.z)
 ```
 """
-struct CameraPoint{T} <: FieldVector{3, T}
+struct CameraPoint{T} <: FieldVector{3,T}
     x::T  # Camera forward direction
     y::T  # Camera right direction
     z::T  # Camera down direction
@@ -120,7 +120,7 @@ println("X: ", pp_centered.x)
 println("Y: ", pp_centered.y)
 ```
 """
-struct ProjectionPoint{T, S} <: FieldVector{2, T}
+struct ProjectionPoint{T,S} <: FieldVector{2,T}
     x::T  # Image x-coordinate (pixels)
     y::T  # Image y-coordinate (pixels)
 end
@@ -131,9 +131,9 @@ end
 # CameraPoint(x, y, z) = CameraPoint{typeof(x)}(x, y, z)
 # CameraPoint(xs::AbstractVector{T}) = CameraPoint{T}(xs)
 # ProjectionPoint(x, y) = ProjectionPoint{typeof(x), :offset}(x, y)  # Default to offset coordinates
-ProjectionPoint(xy::AbstractVector{T}) where {T} = ProjectionPoint{T, :offset}(xy)
-ProjectionPoint(type::Symbol, x::T, y::T) where {T} = ProjectionPoint{T, type}(x, y)  # Default to offset coordinates
-ProjectionPoint{T}(x, y) where {T} = ProjectionPoint{T, :offset}(x, y)
+ProjectionPoint(xy::AbstractVector{T}) where {T} = ProjectionPoint{T,:offset}(xy)
+ProjectionPoint(type::Symbol, x::T, y::T) where {T} = ProjectionPoint{T,type}(x, y)  # Default to offset coordinates
+ProjectionPoint{T}(x, y) where {T} = ProjectionPoint{T,:offset}(x, y)
 
 # Base.BroadcastStyle(::Type{<:WorldPoint}) = Broadcast.ArrayStyle{WorldPoint}()
 # Base.similar(::Broadcast.Broadcasted{Broadcast.ArrayStyle{WorldPoint}}, ::Type{T}) where {T} = WorldPoint{T}(undef)
@@ -141,7 +141,13 @@ ProjectionPoint{T}(x, y) where {T} = ProjectionPoint{T, :offset}(x, y)
 #     WorldPoint{T}(undef, undef, undef)
 
 
-similar_type(::Type{<:ProjectionPoint{T, :centered}}, ::Type{T′}, s::Size{S}) where {T, T′, S} = ProjectionPoint{T′, :centered}
-similar_type(::Type{<:ProjectionPoint{T, :offset}}, ::Type{T′}, s::Size{S}) where {T, T′, S} = ProjectionPoint{T′, :offset}
-similar_type(::Type{<:WorldPoint}, ::Type{T}, s::Size{S}) where {T, S} = WorldPoint{T}
-similar_type(::Type{<:CameraPoint}, ::Type{T}, s::Size{S}) where {T, S} = CameraPoint{T}
+similar_type(::Type{<:ProjectionPoint{T,:centered}}, ::Type{T′}, s::Size{S}) where {T,T′,S} = ProjectionPoint{T′,:centered}
+similar_type(::Type{<:ProjectionPoint{T,:offset}}, ::Type{T′}, s::Size{S}) where {T,T′,S} = ProjectionPoint{T′,:offset}
+similar_type(::Type{<:WorldPoint}, ::Type{T}, s::Size{S}) where {T,S} = WorldPoint{T}
+similar_type(::Type{<:CameraPoint}, ::Type{T}, s::Size{S}) where {T,S} = CameraPoint{T}
+
+
+struct Line{RT<:WithDims(px),TT<:WithDims(rad)}
+    r::RT
+    theta::TT
+end

--- a/src/pose_estimation/optimization.jl
+++ b/src/pose_estimation/optimization.jl
@@ -12,7 +12,7 @@ noise models.
 Custom inverse for upper triangular static matrices using back-substitution.
 Preserves SMatrix type instead of converting to Matrix.
 """
-function LinearAlgebra.inv(U::UpperTriangular{T, <:SMatrix{N,N}}) where {T,N}
+function LinearAlgebra.inv(U::UpperTriangular{T,<:SMatrix{N,N}}) where {T,N}
     A = parent(U)
 
     # Build columns as SVectors, then construct SMatrix from tuple
@@ -25,9 +25,9 @@ function LinearAlgebra.inv(U::UpperTriangular{T, <:SMatrix{N,N}}) where {T,N}
         for i in N:-1:1
             s = b[i]
             for k in i+1:N
-                s -= A[i,k] * x[k]
+                s -= A[i, k] * x[k]
             end
-            x[i] = s / A[i,i]
+            x[i] = s / A[i, i]
         end
 
         SVector{N}(x)
@@ -43,7 +43,7 @@ end
 Custom inverse for lower triangular static matrices using forward-substitution.
 Preserves SMatrix type instead of converting to Matrix.
 """
-function LinearAlgebra.inv(L::LowerTriangular{T, <:SMatrix{N,N}}) where {T,N}
+function LinearAlgebra.inv(L::LowerTriangular{T,<:SMatrix{N,N}}) where {T,N}
     A = parent(L)
 
     # Build columns as SVectors, then construct SMatrix from tuple
@@ -56,9 +56,9 @@ function LinearAlgebra.inv(L::LowerTriangular{T, <:SMatrix{N,N}}) where {T,N}
         for i in 1:N
             s = b[i]
             for k in 1:i-1
-                s -= A[i,k] * x[k]
+                s -= A[i, k] * x[k]
             end
-            x[i] = s / A[i,i]
+            x[i] = s / A[i, i]
         end
 
         SVector{N}(x)
@@ -237,8 +237,6 @@ function pose_optimization_objective_lines(
     cam_rot::Rotation,
     line_features::LineFeatures
 )
-    # Early return for no lines
-    isempty(line_features.world_line_endpoints) && return Float64[]
 
     # Project line endpoints to image coordinates and compute line parameters
     projected_lines = [
@@ -258,7 +256,7 @@ function pose_optimization_objective_lines(
     ]
 
     # Flatten line errors and apply weighting
-    line_errors_vec = reduce(vcat, line_errors)
+    line_errors_vec = reduce(vcat, line_errors; init=SVector{0,Float64}())
     Linv = line_features.Linv
     weighted_errors = Linv * line_errors_vec
 
@@ -310,7 +308,7 @@ function comparelines(l1::Line, l2::Line)
         ustrip(px, r), ustrip(rad, theta)
     end
     (r2, theta2) = let
-        (; r, theta) = l1
+        (; r, theta) = l2
         ustrip(px, r), ustrip(rad, theta)
     end
     resid(r1, theta1, r2, theta2) = SA[

--- a/src/pose_estimation/optimization.jl
+++ b/src/pose_estimation/optimization.jl
@@ -213,11 +213,10 @@ function pose_optimization_objective_points(
 
     # Flatten corner errors and apply weighting
     corner_errors_vec = reduce(vcat, corner_errors)
-    # Strip units before matrix multiplication (Linv is unitless, result scaled by px)
-    corner_errors_unitless = ustrip.(px, corner_errors_vec)
-    weighted_errors = point_features.Linv * corner_errors_unitless
+    Linv = point_features.Linv / 1px
+    weighted_errors = Linv * corner_errors_vec
 
-    return weighted_errors
+    return ustrip.(NoUnits, weighted_errors)
 end
 
 """

--- a/src/pose_estimation/optimization.jl
+++ b/src/pose_estimation/optimization.jl
@@ -10,63 +10,198 @@ noise models.
 abstract type AbstractPoseOptimizationParams end
 
 """
-    PoseOptimizationParams6DOF{T, T′, S, RC, OC, M}
+    PointFeatures{T, T′, T′′, S, RC, OC, CC, M, M′}
+
+Point feature observations and noise model for pose estimation.
+"""
+struct PointFeatures{
+    T,T′,T′′,S,
+    RC<:AbstractVector{WorldPoint{T}},
+    OC<:AbstractVector{ProjectionPoint{T′,S}},
+    CC<:AbstractCameraConfig{S},
+    M<:AbstractMatrix{T′′},
+    M′<:AbstractMatrix{T′′}
+}
+    runway_corners::RC
+    observed_corners::OC
+    camconfig::CC
+    cov::M
+    Linv::M′
+end
+function PointFeatures(runway_corners, observed_corners, camconfig, noisemodel::NoiseModel)
+    cov = covmatrix(noisemodel) |> Matrix
+    return PointFeatures(runway_corners, observed_corners, camconfig, cov)
+end
+function PointFeatures(runway_corners, observed_corners, camconfig, cov::Matrix)
+    U = cholesky(cov).U
+    Linv = Matrix(inv(U'))  # Ensure dense matrix for consistent performance
+    return PointFeatures(runway_corners, observed_corners, camconfig, cov, Linv)
+end
+
+"""
+    LineFeatures{T, T′′, S, WL, OL, CC, M, M′}
+
+Line feature observations and noise model for pose estimation.
+
+# Fields
+- `world_line_endpoints`: Vector of pairs of WorldPoints defining lines in world space
+- `observed_lines`: Vector of Line objects (r, theta) from observations
+- `camconfig`: Camera configuration
+- `cov`: Covariance matrix for observation errors
+- `Linv`: Inverted lower triangular part of covariance
+"""
+struct LineFeatures{
+    T,T′,T′′,S,
+    WL<:AbstractVector{<:Tuple{WorldPoint{T},WorldPoint{T}}},
+    OL<:AbstractVector{Line{T′,T′′}},
+    CC<:AbstractCameraConfig{S},
+    M<:AbstractMatrix,
+    M′<:AbstractMatrix
+}
+    world_line_endpoints::WL
+    observed_lines::OL
+    camconfig::CC
+    cov::M
+    Linv::M′
+end
+function LineFeatures(world_line_endpoints, observed_lines, camconfig, noisemodel::NoiseModel)
+    cov = covmatrix(noisemodel) |> Matrix
+    return LineFeatures(world_line_endpoints, observed_lines, camconfig, cov)
+end
+function LineFeatures(world_line_endpoints, observed_lines, camconfig, cov::Matrix)
+    U = cholesky(cov).U
+    Linv = Matrix(inv(U'))  # Ensure dense matrix for consistent performance
+    return LineFeatures(world_line_endpoints, observed_lines, camconfig, cov, Linv)
+end
+
+# Fully concrete empty line features for when no lines are used
+const NO_LINES = let
+    T = typeof(1.0m)
+    RT = typeof(1.0px)
+    TT = typeof(1.0rad)
+    LineFeatures(
+        Tuple{WorldPoint{T},WorldPoint{T}}[],
+        Line{RT,TT}[],
+        CAMERA_CONFIG_OFFSET,
+        Matrix{Float64}(undef, 0, 0),
+        Matrix{Float64}(undef, 0, 0)
+    )
+end
+
+"""
+    PoseOptimizationParams6DOF{PF, LF}
 
 Parameters for 6-DOF pose optimization (position + attitude).
 """
 struct PoseOptimizationParams6DOF{
-        T, T′, T′′, S,
-        RC <: AbstractVector{WorldPoint{T}},
-        OC <: AbstractVector{ProjectionPoint{T′, S}},
-        CC <: AbstractCameraConfig{S},
-        M <: AbstractMatrix{T′′},
-        M′<: AbstractMatrix{T′′}
-    } <: AbstractPoseOptimizationParams
-    runway_corners::RC
-    observed_corners::OC
-    camconfig::CC
-    cov::M
-    Linv::M′
-end
-function PoseOptimizationParams6DOF(runway_corners, observed_corners, camconfig, noisemodel::NoiseModel)
-    cov = covmatrix(noisemodel) |> Matrix
-    return PoseOptimizationParams6DOF(runway_corners, observed_corners, camconfig, cov)
-end
-function PoseOptimizationParams6DOF(runway_corners, observed_corners, camconfig, cov::Matrix)
-    U = cholesky(cov).U
-    Linv = Matrix(inv(U'))  # Ensure dense matrix for consistent performance
-    return PoseOptimizationParams6DOF(runway_corners, observed_corners, camconfig, cov, Linv)
+    PF<:PointFeatures,
+    LF<:LineFeatures
+} <: AbstractPoseOptimizationParams
+    point_features::PF
+    line_features::LF
 end
 
 """
-    PoseOptimizationParams3DOF{T, T′, S, A, RC, OC, M}
+    PoseOptimizationParams3DOF{A, PF, LF}
 
 Parameters for 3-DOF pose optimization (position only with known attitude).
 """
 struct PoseOptimizationParams3DOF{
-        T, T′, T′′, S,
-        A <: Rotation{3},
-        RC <: AbstractVector{WorldPoint{T}},
-        OC <: AbstractVector{ProjectionPoint{T′, S}},
-        CC <: AbstractCameraConfig{S},
-        M <: AbstractMatrix{T′′},
-        M′<: AbstractMatrix{T′′}
-    } <: AbstractPoseOptimizationParams
-    runway_corners::RC
-    observed_corners::OC
-    camconfig::CC
-    cov::M
-    Linv::M′
+    A<:Rotation{3},
+    PF<:PointFeatures,
+    LF<:LineFeatures
+} <: AbstractPoseOptimizationParams
+    point_features::PF
+    line_features::LF
     known_attitude::A
 end
-function PoseOptimizationParams3DOF(runway_corners, observed_corners, camconfig, noisemodel::NoiseModel, known_attitude)
-    cov = covmatrix(noisemodel) |> Matrix
-    return PoseOptimizationParams3DOF(runway_corners, observed_corners, camconfig, cov, known_attitude)
+
+"""
+    pose_optimization_objective_points(cam_pos, cam_rot, point_features)
+
+Compute weighted point feature residuals.
+
+# Arguments
+- `cam_pos`: Camera position (WorldPoint)
+- `cam_rot`: Camera rotation (Rotation)
+- `point_features`: PointFeatures struct
+
+# Returns
+- Weighted reprojection error vector
+"""
+function pose_optimization_objective_points(
+    cam_pos::WorldPoint,
+    cam_rot::Rotation,
+    point_features::PointFeatures
+)
+    # Project runway corners to image coordinates
+    # WARNING: Don't remove this `let` statement without checking JET tests for type inference.
+    # For some reason it's necessary for type inference to work.
+    projected_corners = let cam_pos = cam_pos
+        [
+            project(cam_pos, cam_rot, corner, point_features.camconfig)
+            for corner in point_features.runway_corners
+        ]
+    end
+
+    # Compute reprojection errors
+    corner_errors = [
+        (proj - obs)
+        for (proj, obs) in zip(projected_corners, point_features.observed_corners)
+    ]
+
+    # Flatten corner errors and apply weighting
+    corner_errors_vec = reduce(vcat, corner_errors)
+    Linv = point_features.Linv / 1px
+    weighted_errors = Linv * corner_errors_vec
+
+    return ustrip.(NoUnits, weighted_errors)
 end
-function PoseOptimizationParams3DOF(runway_corners, observed_corners, camconfig, cov::Matrix, known_attitude)
-    U = cholesky(cov).U
-    Linv = Matrix(inv(U'))  # Ensure dense matrix for consistent performance
-    return PoseOptimizationParams3DOF(runway_corners, observed_corners, camconfig, cov, Linv, known_attitude)
+
+"""
+    pose_optimization_objective_lines(cam_pos, cam_rot, line_features)
+
+Compute weighted line feature residuals.
+
+# Arguments
+- `cam_pos`: Camera position (WorldPoint)
+- `cam_rot`: Camera rotation (Rotation)
+- `line_features`: LineFeatures struct
+
+# Returns
+- Weighted line error vector (empty if no lines)
+"""
+function pose_optimization_objective_lines(
+    cam_pos::WorldPoint,
+    cam_rot::Rotation,
+    line_features::LineFeatures
+)
+    # Early return for no lines
+    isempty(line_features.world_line_endpoints) && return Float64[]
+
+    # Project line endpoints to image coordinates and compute line parameters
+    projected_lines = [
+        # Project both endpoints of each line
+        let p1 = project(cam_pos, cam_rot, endpoints[1], line_features.camconfig),
+            p2 = project(cam_pos, cam_rot, endpoints[2], line_features.camconfig)
+            # Convert projected endpoints to line representation (r, theta)
+            getline(p1, p2)
+        end
+        for endpoints in line_features.world_line_endpoints
+    ]
+
+    # Compute line errors
+    line_errors = [
+        comparelines(lpred, lobs)
+        for (lpred, lobs) in zip(projected_lines, line_features.observed_lines)
+    ]
+
+    # Flatten line errors and apply weighting
+    line_errors_vec = reduce(vcat, line_errors)
+    Linv = line_features.Linv
+    weighted_errors = Linv * line_errors_vec
+
+    return ustrip.(NoUnits, weighted_errors)
 end
 
 """
@@ -81,45 +216,53 @@ Unified optimization function for pose estimation.
 - `ps`: `PoseOptimizationParams6DOF` or `PoseOptimizationParams3DOF`
 
 # Returns
-- Weighted reprojection error vector
+- Weighted reprojection error vector combining point and line features
 """
 function pose_optimization_objective(
-        optvar::AbstractVector{T},
-        ps::AbstractPoseOptimizationParams
-    ) where {T <: Real}
+    optvar::AbstractVector{T},
+    ps::AbstractPoseOptimizationParams
+) where {T<:Real}
     # Extract camera position from optimization variables
     cam_pos = WorldPoint(optvar[1:3]m)
 
     # Determine camera rotation via pattern matching
     cam_rot = @match ps begin
         ps::PoseOptimizationParams6DOF => RotZYX(
-            roll = optvar[4]rad, pitch = optvar[5]rad, yaw = optvar[6]rad
+            roll=optvar[4]rad, pitch=optvar[5]rad, yaw=optvar[6]rad
         )
         ps::PoseOptimizationParams3DOF => ps.known_attitude
     end
 
-    # Project runway corners to image coordinates
-    # WARNING: Don't remove this `let` statement without checking JET tests for type inference.
-    # For some reason it's necessary for type inference to work.
-    projected_corners = let cam_pos = cam_pos
-        [
-            project(cam_pos, cam_rot, corner, ps.camconfig)
-                for corner in ps.runway_corners
-        ]
-    end
+    # Compute point feature residuals
+    point_residuals = pose_optimization_objective_points(cam_pos, cam_rot, ps.point_features)
 
-    # Compute reprojection errors
-    error_vectors = [
-        (proj - obs)
-        for (proj, obs) in zip(projected_corners, ps.observed_corners)
-    ]
-    errors = reduce(vcat, error_vectors)
+    # Compute line feature residuals
+    line_residuals = pose_optimization_objective_lines(cam_pos, cam_rot, ps.line_features)
 
-    Linv = ps.Linv / 1px
-    weighted_errors = Linv * errors
-
-    return ustrip.(NoUnits, weighted_errors)
+    # Combine residuals
+    return vcat(point_residuals, line_residuals)
 end
+
+function comparelines(l1::Line, l2::Line)
+    (r1, theta1) = let
+        (; r, theta) = l1
+        ustrip(px, r), ustrip(rad, theta)
+    end
+    (r2, theta2) = let
+        (; r, theta) = l1
+        ustrip(px, r), ustrip(rad, theta)
+    end
+    resid(r1, theta1, r2, theta2) = SA[
+        r1 - r2
+        cos(theta1) - cos(theta2)
+        sin(theta1) - sin(theta2)
+    ]
+    resid1 = resid(r1, theta1, r2, theta2)
+    resid2 = resid(r1, theta1, -r2, theta2 + pi)
+    return (norm(resid1) < norm(resid2) ? resid1 : resid2)
+end
+
+
 
 function setup_for_precompile()
     runway_corners = [
@@ -129,18 +272,19 @@ function setup_for_precompile()
         WorldPoint(3000.0m, -50.0m, 0.0m),
     ]
     true_pos = WorldPoint(-1300.0m, 0.0m, 80.0m)
-    true_rot = RotZYX(roll = 0.03, pitch = 0.04, yaw = 0.05)
+    true_rot = RotZYX(roll=0.03, pitch=0.04, yaw=0.05)
     projections = [project(true_pos, true_rot, corner, CAMERA_CONFIG_OFFSET) for corner in runway_corners]
     return (; runway_corners, projections, true_pos, true_rot)
 end
 
 
-const _defaultnoisemodel(pts) = let
-    distributions = [SA[Normal(0.0, 2.0), Normal(0.0, 2.0)] for _ in pts] |> Array
-    UncorrGaussianNoiseModel(reduce(vcat, distributions))
-end
+const _defaultnoisemodel(pts) =
+    let
+        distributions = [SA[Normal(0.0, 2.0), Normal(0.0, 2.0)] for _ in pts] |> Array
+        UncorrGaussianNoiseModel(reduce(vcat, distributions))
+    end
 
-const AD = AutoForwardDiff(; chunksize = 1)
+const AD = AutoForwardDiff(; chunksize=1)
 const POSEOPTFN = NonlinearFunction{false,FullSpecialize}(pose_optimization_objective)
 const ALG = LevenbergMarquardt(; autodiff=AD, linsolve=CholeskyFactorization(),
     disable_geodesic=Val(true))
@@ -152,10 +296,8 @@ const S4COMP = :offset
 const CACHE_6DOF = let
     (; runway_corners, projections, true_pos, true_rot) = setup_for_precompile()
     noise_model = _defaultnoisemodel(projections)
-    ps = PoseOptimizationParams6DOF(
-        runway_corners, projections,
-        CAMERA_CONFIG_OFFSET, noise_model
-    )
+    point_features = PointFeatures(runway_corners, projections, CAMERA_CONFIG_OFFSET, noise_model)
+    ps = PoseOptimizationParams6DOF(point_features, NO_LINES)
     prob = NonlinearLeastSquaresProblem{false}(POSEOPTFN, rand(6), ps)
     T = Float64
     # sqrt of the default
@@ -167,11 +309,8 @@ end
 const CACHE_3DOF = let
     (; runway_corners, projections, true_pos, true_rot) = setup_for_precompile()
     noise_model = _defaultnoisemodel(projections)
-    ps = PoseOptimizationParams3DOF(
-        runway_corners, projections,
-        CAMERA_CONFIG_OFFSET, noise_model,
-        true_rot
-    )
+    point_features = PointFeatures(runway_corners, projections, CAMERA_CONFIG_OFFSET, noise_model)
+    ps = PoseOptimizationParams3DOF(point_features, NO_LINES, true_rot)
     prob = NonlinearLeastSquaresProblem{false}(POSEOPTFN, rand(3), ps)
     T = Float64
     # sqrt of the default
@@ -181,14 +320,14 @@ const CACHE_3DOF = let
 end
 
 function estimatepose6dof(
-        runway_corners::AbstractVector{<:WorldPoint},
-        observed_corners::AbstractVector{<:ProjectionPoint{T, S}},
-        camconfig::AbstractCameraConfig{S} = CAMERA_CONFIG_OFFSET,
-        noise_model::N = _defaultnoisemodel(observed_corners);
-        initial_guess_pos::AbstractVector{<:Length} = SA[-1000.0, 0.0, 100.0]m,
-        initial_guess_rot::AbstractVector{<:DimensionlessQuantity} = SA[0.0, 0.0, 0.0]rad,
-        optimization_config = DEFAULT_OPTIMIZATION_CONFIG
-    ) where {T, S, N}
+    runway_corners::AbstractVector{<:WorldPoint},
+    observed_corners::AbstractVector{<:ProjectionPoint{T,S}},
+    camconfig::AbstractCameraConfig{S}=CAMERA_CONFIG_OFFSET,
+    noise_model::N=_defaultnoisemodel(observed_corners);
+    initial_guess_pos::AbstractVector{<:Length}=SA[-1000.0, 0.0, 100.0]m,
+    initial_guess_rot::AbstractVector{<:DimensionlessQuantity}=SA[0.0, 0.0, 0.0]rad,
+    optimization_config=DEFAULT_OPTIMIZATION_CONFIG
+) where {T,S,N}
     u₀ = [
         initial_guess_pos .|> _ustrip(m);
         initial_guess_rot .|> _ustrip(rad)
@@ -197,52 +336,54 @@ function estimatepose6dof(
     # for precompile we need the correct types
     observed_corners = [
         convertcamconf(CAMCONF4COMP, camconfig, proj)
-            for proj in observed_corners
+        for proj in observed_corners
     ]
-    ps = PoseOptimizationParams6DOF(
+    point_features = PointFeatures(
         runway_corners |> Vector, observed_corners |> Vector,
         CameraConfig{S4COMP}(camconfig), noise_model
     )
+    ps = PoseOptimizationParams6DOF(point_features, NO_LINES)
 
     # Get or create cache for this problem size
     cache = CACHE_6DOF
     reinit!(cache, u₀; p=ps)
     solve!(cache)
-    sol = (; u = cache.u, retcode = cache.retcode)
+    sol = (; u=cache.u, retcode=cache.retcode)
 
     !successful_retcode(sol.retcode) && throw(OptimizationFailedError(sol.retcode, sol))
     pos = WorldPoint(sol.u[1:3]m)
-    rot = RotZYX(roll = sol.u[4]rad, pitch = sol.u[5]rad, yaw = sol.u[6]rad)
+    rot = RotZYX(roll=sol.u[4]rad, pitch=sol.u[5]rad, yaw=sol.u[6]rad)
     return (; pos, rot)
 end
 
 function estimatepose3dof(
-        runway_corners::AbstractVector{<:WorldPoint},
-        observed_corners::AbstractVector{<:ProjectionPoint{T, S}},
-        known_attitude::RotZYX,
-        camconfig::AbstractCameraConfig{S} = CAMERA_CONFIG_OFFSET,
-        noise_model::N = _defaultnoisemodel(observed_corners);
-        initial_guess_pos::AbstractVector{<:Length} = SA[-1000.0, 0.0, 100.0]m,
-        optimization_config = DEFAULT_OPTIMIZATION_CONFIG
-    ) where {T, S, N}
+    runway_corners::AbstractVector{<:WorldPoint},
+    observed_corners::AbstractVector{<:ProjectionPoint{T,S}},
+    known_attitude::RotZYX,
+    camconfig::AbstractCameraConfig{S}=CAMERA_CONFIG_OFFSET,
+    noise_model::N=_defaultnoisemodel(observed_corners);
+    initial_guess_pos::AbstractVector{<:Length}=SA[-1000.0, 0.0, 100.0]m,
+    optimization_config=DEFAULT_OPTIMIZATION_CONFIG
+) where {T,S,N}
 
     u₀ = initial_guess_pos .|> _ustrip(m) |> Array
 
     # for precompile we need the correct types
     observed_corners = [
         convertcamconf(CAMCONF4COMP, camconfig, proj)
-            for proj in observed_corners
+        for proj in observed_corners
     ]
-    ps = PoseOptimizationParams3DOF(
+    point_features = PointFeatures(
         runway_corners |> Vector, observed_corners |> Vector,
-        CameraConfig{S4COMP}(camconfig), noise_model, known_attitude
+        CameraConfig{S4COMP}(camconfig), noise_model
     )
+    ps = PoseOptimizationParams3DOF(point_features, NO_LINES, known_attitude)
 
     # Get or create cache for this problem size
     cache = CACHE_3DOF
     reinit!(cache, u₀; p=ps)
     solve!(cache)
-    sol = (; u = cache.u, retcode = cache.retcode)
+    sol = (; u=cache.u, retcode=cache.retcode)
 
     !successful_retcode(sol.retcode) && throw(OptimizationFailedError(sol.retcode, sol))
     pos = WorldPoint(sol.u[1:3]m)


### PR DESCRIPTION
## Summary
- Implement `getline` function to convert projection points to Hough transform parameters (r, theta)
- Add line feature support for pose estimation with static array compatibility
- Fix type stability in `pose_optimization_objective_lines` using `init` parameter
- Add comprehensive smoke tests for line features and combined point+line features

## Changes
### Core Implementation
- Add `getline` function in `src/camera_model/projection.jl` that converts two `ProjectionPoint`s to `Line` (r, theta) representation using Hough transform
- Use `normalize`, `dot`, and `atan` for clean implementation with proper unit handling
- Export `getline` from main module

### Type Stability
- Fix empty collection error in `pose_optimization_objective_lines` by using `reduce(vcat, line_errors; init=SVector{0,Float64}())`
- Ensures type stability when no lines are present while maintaining `SVector` return type when using `SMatrix` covariance

### Testing
- Add smoke tests for line features with static arrays (`SMatrix` covariance)
- Add smoke test for combined point and line features
- Verify that `SVector` is returned when using `SMatrix` covariance for both points and lines
- All 98 relevant tests passing (1 unrelated JET precompilation error in C API tests)

## Test Results
```
Test Summary:           | Pass  Total
RunwayPoseEstimation.jl |   98     98
  Coordinate Systems    |   15     15
  Camera Model          |   49     49
  Pose Estimation       |   34     34
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)