### PR TITLE
Unfork airpseed velocity

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,8 +10,6 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: RomeoV/AirspeedVelocity.jl@set-project-toml
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
-          julia-version: '1'
-          script: "benchmark/benchmarks.jl"
           enable-plots: true


### PR DESCRIPTION
We can do this because we just have one fork left which is only there to appease a JET error, which doesn't matter for the benchmark.