### PR TITLE
CompatHelper: bump compat for DataStructures to 0.19 for package juliac, (keep existing compat)

### DIFF
--- a/juliac/Project.toml
+++ b/juliac/Project.toml
@@ -1,10 +1,8 @@
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 RunwayLib = "c31d23ff-e9b5-4186-8ef8-ce4d62614c67"
 
 [compat]
-DataStructures = "0.18, 0.19"
 JuliaC = "0.2"
 
 [preferences.LinearSolve]


### PR DESCRIPTION
Closes #61