### PR TITLE
[WIP] Remove JuliaC@0.2.2 requirement

### DIFF
--- a/juliac/Project.toml
+++ b/juliac/Project.toml
@@ -1,11 +1,9 @@
 [deps]
 JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 RunwayLib = "c31d23ff-e9b5-4186-8ef8-ce4d62614c67"
-PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
-JuliaC = "=0.2.0, =0.2.2"
-PackageCompiler = "2.0.0 - 2.2.3"
+JuliaC = "0.2"
 
 [preferences.LinearSolve]
 LoadMKL_JLL = false


### PR DESCRIPTION
Previously there was an incompatibility for 0.2.3 between JuliaC and
PackageCompiler. Let's see if that's still there.